### PR TITLE
Fix nomino movement logic

### DIFF
--- a/game_world_manager.gd
+++ b/game_world_manager.gd
@@ -398,11 +398,13 @@ func place_nomino(n):
 		return
 
 	# Create the Nomino sprite and add to NominoLayer
-	var sprite = NOMINO_SCENE.instantiate()
-	# Set species property before adding to scene
-	sprite.species = n.species
-	# Add to Nominos group for group management
-	sprite.add_to_group("Nominos")
+       var sprite = NOMINO_SCENE.instantiate()
+       # Set species property before adding to scene
+       sprite.species = n.species
+       sprite.move_types = n.move_types.duplicate()
+       sprite.nomino_data = n
+       # Add to Nominos group for group management
+       sprite.add_to_group("Nominos")
 
 	# Connect the request_move signal to the world manager
 	sprite.request_move.connect(_on_nomino_request_move.bind(n))

--- a/nomino.gd
+++ b/nomino.gd
@@ -4,6 +4,7 @@ extends Node2D
 var move_types: Array[String] = []  # e.g. ["orthostep", "diagstep"]
 var timer: Timer
 var original_position: Vector2
+var nomino_data: Resource # Reference to associated NominoData
 
 var sprite: Sprite2D
 
@@ -61,16 +62,16 @@ func _on_timer_timeout():
 	tw.tween_property(sprite, "position:y", sprite.position.y - jump_height, jump_duration).set_trans(Tween.TRANS_CUBIC).set_ease(Tween.EASE_OUT)
 	tw.tween_property(sprite, "position:y", 0, fall_duration).set_trans(Tween.TRANS_CUBIC).set_ease(Tween.EASE_IN)
 
-	# --- Nomino autonomous movement logic ---
-	# Pick a random move from move_types, if any
-	if move_types.size() > 0:
-		var move_pattern = move_types[randi() % move_types.size()]
-		if NOMINO_MOVES.has(move_pattern):
-			var options = NOMINO_MOVES[move_pattern]
-			var delta = options[randi() % options.size()]
-			# Request a move via signal (let world manager validate and apply)
-			var new_pos = Vector2i(int(position.x), int(position.y)) + Vector2i(int(delta.x), int(delta.y))
-			emit_signal("request_move", new_pos)
+       # --- Nomino autonomous movement logic ---
+       # Pick a random move from move_types, if any
+       if move_types.size() > 0 and nomino_data:
+               var move_pattern = move_types[randi() % move_types.size()]
+               if NOMINO_MOVES.has(move_pattern):
+                       var options = NOMINO_MOVES[move_pattern]
+                       var delta = options[randi() % options.size()]
+                       # Request a move via signal using world coordinates
+                       var new_pos = nomino_data.pos + Vector2i(int(delta.x), int(delta.y))
+                       emit_signal("request_move", new_pos)
 
 const NOMINO_MOVES = {
 	"orthostep": [Vector2(0, -1), Vector2(-1, 0), Vector2(1, 0), Vector2(0, 1)],


### PR DESCRIPTION
## Summary
- associate each Nomino node with its `NominoData`
- use world coordinates when emitting a move request
- pass move types and data when instantiating Nominos

## Testing
- `pytest -q` *(fails: no tests found)*

------
https://chatgpt.com/codex/tasks/task_e_684774b3821c832d84af48edf48c6e51